### PR TITLE
Fix bug in sensitivity routines that occurs when using Pardiso solver

### DIFF
--- a/src/MaxwellTime.jl
+++ b/src/MaxwellTime.jl
@@ -13,6 +13,13 @@ try
 catch
 end
 
+hasPardiso = false
+try
+    using Pardiso
+    hasPardiso = true
+catch
+end
+
 # We will add MaxwellTime specific subtypes/methods
 # to the following jInv generics
 import jInv.ForwardShare.ForwardProbType

--- a/src/MaxwellTimeParam.jl
+++ b/src/MaxwellTimeParam.jl
@@ -146,14 +146,14 @@ Input:  Mandatory arguments:
                                we'll add exponential integrators at some
                                point too.
 
-        EMSolverType::Symbol - Linear solver for EM time-stepping solves.
+        EMsolverType::Symbol - Linear solver for EM time-stepping solves.
                                Currently supported options
                                are :MUMPS, :Pardiso and :JuliaSolver (to use
                                Julia's built in sparse Cholesky routine,
                                which I believe is cholmod, from SuiteSparse).
                                Default is :MUMPS
 
-        DCSolverType::Symbol - Solver for DC problem for galvanic sources.
+        DCsolverType::Symbol - Solver for DC problem for galvanic sources.
                                Same options as EMSolverType.
 
 

--- a/src/MaxwellTimeParam.jl
+++ b/src/MaxwellTimeParam.jl
@@ -186,18 +186,18 @@ function getMaxwellTimeParam{S<:Real}(Mesh::AbstractMesh,
 
     # Setup solvers based on input options
     if DCsolverType == :MUMPS
-        DCsolver = getMUMPSsolver([],1,0,1)
+        DCsolver = hasMUMPS ? getMUMPSsolver([],1,0,1) : error("Unable to load MUMPS")
     elseif DCsolverType ==:Pardiso
-        error("Not set up yet")
-        #warn("DC problem can be unstable w Pardiso for large problems")
+        DCsolver = getjInvPardisoSolver([],1,0,2,1) : error("Unable to load Pardiso")
+        warn("DC problem can be unstable w Pardiso for large problems")
     elseif DCsolverType == :juliaSolver
         DCsolver = getJuliaSolver(sym=1)
     end
 
     if EMsolverType == :MUMPS
-        baseEMSolver = getMUMPSsolver([],1,0,1)
+        baseEMSolver = hasMUMPS ? getMUMPSsolver([],1,0,1) : error("Unable to load MUMPS")
     elseif EMsolverType ==:Pardiso
-        error("Pardiso solver will be supported soon!")
+        baseEMSolver = hasPardiso ? getjInvPardisoSolver([],1,0,2,1) : error("Unable to load Pardiso")
     elseif EMsolverType == :juliaSolver
         baseEMSolver = getJuliaSolver(sym=1)
     else

--- a/src/getFields.jl
+++ b/src/getFields.jl
@@ -114,7 +114,7 @@ function getFieldsBDF2{T,N}(K::SparseMatrixCSC{T,N},
             rhs = ( (-g1*wave[i+1]+g2*wave[i]-g3*wave[i-1])*s +
                              Msig*(g2*ew[:,:,i] - g3*ew[:,:,i-1]) )/dt[i]
             M = Y -> begin
-                         Y = hasMUMPS ? applyMUMPS(EMsolvers[iSolver].Ainv,Y) : EMsolvers[iSolver].Ainv\Y 
+                         Y = hasMUMPS ? applyMUMPS(EMsolvers[iSolver].Ainv,Y) : EMsolvers[iSolver].Ainv\Y
                          return Y
                      end
             for j = 1:size(rhs,2)

--- a/src/getSensMatVec.jl
+++ b/src/getSensMatVec.jl
@@ -184,7 +184,7 @@ function getSensMatVecBE{T<:Real}(DsigDmz::Vector{T},DmuDmz::Vector{T},
 
     iSolver     = 0
     uniqueSteps = unique(dt)
-    A           = spzeros(T,0,0)
+    A           = speye(size(Ne,2)) #spzeros(T,0,0)
     for i=1:nt
         # Form A when needed. It is not stored or formed if
         # param.storageLevel == :Factors
@@ -350,7 +350,7 @@ function getSensMatVecBDF2{T<:Real}(DsigDmz::Vector{T},DmuDmz::Vector{T},
         error("Inverting for mu with bdf2 time-stepping not yet supported")
     end
     uniqueSteps = unique(dt)
-    A           = spzeros(T,0,0)
+    A           = speye(size(Ne,2)) # spzeros(T,0,0)
     A,iSolver   = getBDF2ConstDTmatrix!(dt[1],A,K,Msig,param,uniqueSteps)
     for j = 1:ns
         Gzi                 = 3/(2*dt[1])*Ne'*getdEdgeMassMatrix(Mesh,Ne*(ehat[:,j]-ew[:,j,1]))
@@ -522,7 +522,7 @@ function getSensMatVecBDF2ConstDT{T<:Real}(DsigDmz::Vector{T},DmuDmz::Vector{T},
         error("Inverting for mu with bdf2 time-stepping not yet supported")
     end
     uniqueSteps = [dt]
-    A           = spzeros(T,0,0)
+    A           = speye(size(Ne,2)) #spzeros(T,0,0)
     A,iSolver   = getBDF2ConstDTmatrix!(dt,A,K,Msig,param,uniqueSteps)
     for j = 1:ns
         Gzi                 = 3/(2*dt)*Ne'*getdEdgeMassMatrix(M,Ne*(ehat[:,j]-ew[:,j,1]))

--- a/src/getSensTMatVec.jl
+++ b/src/getSensTMatVec.jl
@@ -121,7 +121,7 @@ function getSensTMatVecBE{T<:Real}(z::Vector{T},model::MaxwellTimeModel,
     JTvMu       = zeros(T,length(mu))
     dt          = [dt[:];dt[end]]
     uniqueSteps = unique(dt)
-    A           = spzeros(T,0,0)
+    A           = speye(size(Ne,2)) #spzeros(T,0,0)
     iSolver     = 0
     dtLast      = -1.0 # Size of last time step, used to check if
                       # factorization of Forward mod. matrix is needed.
@@ -268,7 +268,7 @@ function getSensTMatVecBDF2{T<:Real}(z::Vector{T},model::MaxwellTimeModel,
 #      JTvMu    = 0
     JTv = zeros(T,Mesh.nc)
     uniqueSteps = unique(dt)
-    A           = spzeros(T,0,0)
+    A           = speye(size(Ne,2)) #spzeros(T,0,0)
     iSolver     = 0
     #A,iSolver   = getBDF2ConstDTmatrix!(dt[end],A,K,Msig,param,uniqueSteps)
     dt          = [dt;dt[end];dt[end]]
@@ -465,7 +465,7 @@ function getSensTMatVecBDF2ConstDT{T<:Real}(z::Vector{T},model::MaxwellTimeModel
 #     JTvMu    = 0
     JTv = 0
     uniqueSteps = [dt]
-    A           = spzeros(T,0,0)
+    A           = speye(size(Ne,2)) #spzeros(T,0,0)
     A,iSolver   = getBDF2ConstDTmatrix!(dt,A,K,Msig,param,uniqueSteps)
     for i=nt:-1:2
       for j = 1:ns


### PR DESCRIPTION
Need to supply a matrix of correct size to pardiso even when only doing solve phase.