### PR TITLE
Fix matrix-vector products with MaxwellTimeModelDerivative

### DIFF
--- a/src/MaxwellTimeModel.jl
+++ b/src/MaxwellTimeModel.jl
@@ -69,7 +69,7 @@ end
 
 function *{T<:Real}(D::MaxwellTimeModelDerivative, x::Vector{T})
     values = Dict{String,Vector{T}}()
-    for key in D.activeInversionProperties
+    for key in keys(D.mats)
         values[key] = D.mats[key]*x
     end
     MaxwellTimeModel(values,D.activeInversionProperties)
@@ -79,7 +79,7 @@ function Ac_mul_B(D::MaxwellTimeModelDerivative, y::MaxwellTimeModel)
     key1 = first(keys(D.mats))
     T    = eltype(D.mats[key1])
     xOut = zeros(T,size(D.mats[key1],2))
-    for key in D.activeInversionProperties
+    for key in keys(D.mats)
         xOut += D.mats[key]'*y.values[key]
     end
     return xOut


### PR DESCRIPTION
The way I'm using MaxwellTimeModelDerivative, the matrix-vector products need to create/operate on a full model containing both sigmaCell and muCell, even if one of them is not an active inversion property. Does this break other examples? @Pbellive 